### PR TITLE
bug/CONNECT1-685/android-sdk-not-closing-on

### DIFF
--- a/alloy-web-sdk/src/App.js
+++ b/alloy-web-sdk/src/App.js
@@ -1,4 +1,3 @@
-import logo from './logo.svg';
 import alloy from '@alloyidentity/web-sdk';
 import './App.css';
 

--- a/sdk/src/main/java/co/alloy/codelesssdklite/WebViewInterface.kt
+++ b/sdk/src/main/java/co/alloy/codelesssdklite/WebViewInterface.kt
@@ -11,13 +11,17 @@ class WebViewInterface {
         when (result.getString("status").lowercase()) {
             "closed" -> Alloy.finishCancelled()
             "pending_step_up" -> Alloy.finishCancelled()
+            "expired" -> Alloy.finishCancelled()
+            "waiting_review" -> Alloy.finishCancelled()
             "completed" -> {
                 when (result.getString("outcome").lowercase()) {
                     "approved" -> Alloy.finishSuccess()
                     "manual review" -> Alloy.finishManualReview()
                     "denied" -> Alloy.finishDenied()
+                    else -> Alloy.finishDenied()
                 }
             }
+            else -> Alloy.finishCancelled()
         }
     }
 


### PR DESCRIPTION
<!--

*------- PR Requirements -------*

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* The pull request must have a Clubhouse ticket attached. We're trying to make sure all changes are requested and tracked, so make sure there is a ticket!
* The pull request must update the test suite to exercise the updated functionality. 
* After you create the pull request, all status checks must pass before a maintainer reviews your contribution.

*------------------------------*

-->

## Context/Background
Certain journey statuses were not being accounted for, this PR resolves this by accounting for any journey status
<!--

Include any context not present in the ticket. If your change touches many areas of the code, include an overview of those areas.

-->

## Description of the Change
Handle all journey statuses by adding default closing behavior


https://github.com/UseAlloy/alloy-codeless-lite-android/assets/114195649/4c9cbe2c-b308-4778-ab84-dd6573510986


<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

It is often helpful to show a before/after screenshot or gif/video; Markdown tables can help make those readable, like so:
| Before                               | After                                |
| :----------------------------------- | :----------------------------------- |
| ![](http://before.image.link)        | ![](http://url.for.after.image)      |
| ![](https://i.imgur.com/XFqHtXE.jpg) | ![](https://i.imgur.com/XFqHtXE.jpg) |

<details open>
  <summary>collapsable sections</summary>
  You can also create collapsable sections for greater detail. These can include Markdown.
</details>

-->

## Steps To Test
* Run the SDK in Andoid Studio
* click on both `Start Alloy` and `Create Journey Application` buttons
* When concluding flow, click `Exit` and app should reset
<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (including buttons you clicked, text you typed, commands you ran, etc.), and describe the results you observed.

This lets reviewers check that you've considered all the cases your code could touch.

-->

## Testing
N/A
<!--

What automated tests do we have around this change?

- If it is new code, are all parts tested?
- If changing existing code, did you have to update any tests?
- If changing existing code, did you add tests to cover the change?

Also, if you are touching old code, did you add additional tests, cause additional tests makes everyone happy!

Remember, types of tests you can have:

- unit tests
- integrations tests
- end to end tests

-->

## Possible Drawbacks
No apparent drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

## Security & Privacy
N/A

<!-- Any significant security related changes/concerns to note. This includes changes to authentication/authorization, data privacy, networking, major configuration changes, among others. 

For example, 
- this change enables a feature flag will allow users with the `xyz` role to make config changes
- this change makes the cluster accessible to a specific VPC

-->

<!--
Notes:

Try to keep your PR under 500 LOC. If your change is large, group it into PRs based on logical areas (adding a component, adding an API endpoint, etc).

-->
