### PR TITLE
remove dependency on status

### DIFF
--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -50,7 +50,7 @@ afterEvaluate {
                 from components.release
                 groupId 'co.alloy.codelesssdklite'
                 artifactId 'sdk'
-                version '1.0.12'
+                version '1.0.13'
             }
         }
 

--- a/sdk/src/main/java/co/alloy/codelesssdklite/Alloy.kt
+++ b/sdk/src/main/java/co/alloy/codelesssdklite/Alloy.kt
@@ -4,6 +4,9 @@ import android.content.Context
 
 object Alloy {
     interface Listener {
+        fun onDone() {
+            logd("onDone")
+        }
         fun onCancelled() {}
         fun onSuccess() {}
         fun onDenied() {}
@@ -37,6 +40,11 @@ object Alloy {
 
     internal fun finishCancelled() {
         listener?.onCancelled()
+        closeActivityListener?.invoke()
+    }
+
+    internal fun finish() {
+        listener?.onDone()
         closeActivityListener?.invoke()
     }
 

--- a/sdk/src/main/java/co/alloy/codelesssdklite/WebViewInterface.kt
+++ b/sdk/src/main/java/co/alloy/codelesssdklite/WebViewInterface.kt
@@ -7,22 +7,7 @@ class WebViewInterface {
     @JavascriptInterface
     fun startAlloy(data: String) {
         logd(data)
-        val result = JSONObject(data)
-        when (result.getString("status").lowercase()) {
-            "closed" -> Alloy.finishCancelled()
-            "pending_step_up" -> Alloy.finishCancelled()
-            "expired" -> Alloy.finishCancelled()
-            "waiting_review" -> Alloy.finishCancelled()
-            "completed" -> {
-                when (result.getString("outcome").lowercase()) {
-                    "approved" -> Alloy.finishSuccess()
-                    "manual review" -> Alloy.finishManualReview()
-                    "denied" -> Alloy.finishDenied()
-                    else -> Alloy.finishDenied()
-                }
-            }
-            else -> Alloy.finishCancelled()
-        }
+        Alloy.finishCancelled()
     }
 
     @JavascriptInterface

--- a/sdk/src/main/java/co/alloy/codelesssdklite/WebViewInterface.kt
+++ b/sdk/src/main/java/co/alloy/codelesssdklite/WebViewInterface.kt
@@ -7,7 +7,15 @@ class WebViewInterface {
     @JavascriptInterface
     fun startAlloy(data: String) {
         logd(data)
-        Alloy.finishCancelled()
+        val result = JSONObject(data)
+        when (result.getString("status").lowercase()) {
+            "closed" -> Alloy.finish()
+            "pending_step_up" -> Alloy.finish()
+            "expired" -> Alloy.finish()
+            "waiting_review" -> Alloy.finish()
+            "completed" -> Alloy.finish()
+            else -> Alloy.finish()
+        }
     }
 
     @JavascriptInterface


### PR DESCRIPTION
## Context/Background
Remove the `outcome` check as it is now deprecated

## Description of the Change
* closing the SDK only accounts for the journey status now
* add `onDone` function to be as used as the generic closing method

## Steps To Test
N/A

## Testing
N/A

## Possible Drawbacks
N/A

## Security & Privacy
N/A