### PR TITLE
bug/CONNECT1-796/android-callback-issue

### DIFF
--- a/app/src/main/java/co/alloy/codelesssdklite/example/MainActivity.kt
+++ b/app/src/main/java/co/alloy/codelesssdklite/example/MainActivity.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.res.stringResource
 import co.alloy.codelesssdklite.Alloy
 import co.alloy.codelesssdklite.AlloySettings
 import co.alloy.codelesssdklite.example.ui.theme.AlloyCodelessSdkLiteTheme
+import org.json.JSONObject
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -35,10 +36,10 @@ class MainActivity : ComponentActivity() {
         )
 
         val settings = AlloySettings(
-            apiKey = "9ca83767-f213-4aaf-bc1b-1ed0a89eaf23",
+            apiKey = "22501763-79c3-4f8d-a069-ce99afad16d5",
             production = false,
             journeyToken = "J-UMEhLDP3p759425pz1uP",
-            journeyApplicationToken = "JA-eJ8aIOG5UhmL0liGeAlz",
+            journeyApplicationToken = "JA-jxNgt4WHD6ttq7KyHVAw",
             journeyData = journeyData,
         )
 
@@ -56,7 +57,11 @@ class MainActivity : ComponentActivity() {
             }
 
             override fun onSuccess() {
-                Log.d("AlloyDemo", "onSuccess")
+
+            }
+
+            override fun onDone(result: JSONObject) {
+                Log.d("AlloyDemo", "onDone ---->  $result")
             }
 
             override fun journeyApplicationTokenCreated(token: String) {

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -50,7 +50,7 @@ afterEvaluate {
                 from components.release
                 groupId 'co.alloy.codelesssdklite'
                 artifactId 'sdk'
-                version '1.0.14'
+                version '1.0.15'
             }
         }
 

--- a/sdk/src/main/java/co/alloy/codelesssdklite/Alloy.kt
+++ b/sdk/src/main/java/co/alloy/codelesssdklite/Alloy.kt
@@ -1,12 +1,11 @@
 package co.alloy.codelesssdklite
 
 import android.content.Context
+import org.json.JSONObject
 
 object Alloy {
     interface Listener {
-        fun onDone() {
-            logd("onDone")
-        }
+        fun onDone(result: JSONObject) {}
         fun onCancelled() {}
         fun onSuccess() {}
         fun onDenied() {}
@@ -43,8 +42,8 @@ object Alloy {
         closeActivityListener?.invoke()
     }
 
-    internal fun finish() {
-        listener?.onDone()
+    internal fun finish(result:JSONObject) {
+        listener?.onDone(result)
         closeActivityListener?.invoke()
     }
 

--- a/sdk/src/main/java/co/alloy/codelesssdklite/WebViewInterface.kt
+++ b/sdk/src/main/java/co/alloy/codelesssdklite/WebViewInterface.kt
@@ -9,12 +9,12 @@ class WebViewInterface {
         logd(data)
         val result = JSONObject(data)
         when (result.getString("status").lowercase()) {
-            "closed" -> Alloy.finish()
-            "pending_step_up" -> Alloy.finish()
-            "expired" -> Alloy.finish()
-            "waiting_review" -> Alloy.finish()
-            "completed" -> Alloy.finish()
-            else -> Alloy.finish()
+            "closed" -> Alloy.finish(result)
+            "pending_step_up" -> Alloy.finish(result)
+            "expired" -> Alloy.finish(result)
+            "waiting_review" -> Alloy.finish(result)
+            "completed" -> Alloy.finish(result)
+            else -> Alloy.finish(result)
         }
     }
 


### PR DESCRIPTION
## Context/Background

Our customer complaint we don't have a callback option for android, but we do have it for IOS. This PR try to fix this problem by adding the result of the callback. 

## Description of the Change

Added the result of the JSON on a listener.

## Steps To Test

1) Run it locally. 
2) Use the example. Will return the value of the entire journey application to be used on the main application.

## Testing

N/A

## Possible Drawbacks

None.

## Security & Privacy

We want to deprecate this callbacks, but the client expect this parity. So we will need to add this and then start our approach to deprecate this. One option will be to disable it on the service side on the client key settings. By doing this that we can keep backward compatibility and ensure we increase our security posture onwards.
